### PR TITLE
Refactor opengl examples to reduce code duplication and fix warnings

### DIFF
--- a/src/org/lwjgl/demo/opengl/Example.java
+++ b/src/org/lwjgl/demo/opengl/Example.java
@@ -1,0 +1,126 @@
+package org.lwjgl.demo.opengl;
+
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.glfw.GLFWFramebufferSizeCallback;
+import org.lwjgl.glfw.GLFWKeyCallback;
+import org.lwjgl.glfw.GLFWVidMode;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GLCapabilities;
+import org.lwjgl.opengl.GLUtil;
+import org.lwjgl.system.Callback;
+
+import java.io.IOException;
+
+import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL11.glClearColor;
+import static org.lwjgl.opengl.GL11.glViewport;
+import static org.lwjgl.system.MemoryUtil.NULL;
+
+public abstract class Example {
+    private long window;
+
+    protected int width = 1024;
+    protected int height = 768;
+
+    protected GLCapabilities caps;
+
+    protected GLFWErrorCallback errCallback;
+    protected GLFWKeyCallback keyCallback;
+    protected GLFWFramebufferSizeCallback fbCallback;
+    protected Callback debugProc;
+
+    protected  void init() throws IOException {
+        glfwSetErrorCallback(errCallback = new GLFWErrorCallback() {
+            GLFWErrorCallback delegate = GLFWErrorCallback.createPrint(System.err);
+
+            @Override
+            public void invoke(int error, long description) {
+                if (error == GLFW_VERSION_UNAVAILABLE)
+                    System.err.println("This demo requires OpenGL 2.0 or higher.");
+                delegate.invoke(error, description);
+            }
+
+            @Override
+            public void free() {
+                delegate.free();
+            }
+        });
+
+        if (!glfwInit())
+            throw new IllegalStateException("Unable to initialize GLFW");
+
+        glfwDefaultWindowHints();
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
+
+        window = glfwCreateWindow(width, height, "Immediate mode shader demo", NULL, NULL);
+        if (window == NULL) {
+            throw new AssertionError("Failed to create the GLFW window");
+        }
+
+        glfwSetFramebufferSizeCallback(window, fbCallback = new GLFWFramebufferSizeCallback() {
+            @Override
+            public void invoke(long window, int width, int height) {
+                if (width > 0 && height > 0 && (width != Example.this.width || height != Example.this.height)) {
+                    Example.this.width = width;
+                    Example.this.height = height;
+                }
+            }
+        });
+
+        glfwSetKeyCallback(window, keyCallback = new GLFWKeyCallback() {
+            @Override
+            public void invoke(long window, int key, int scancode, int action, int mods) {
+                if (action != GLFW_RELEASE)
+                    return;
+
+                if (key == GLFW_KEY_ESCAPE) {
+                    glfwSetWindowShouldClose(window, true);
+                }
+            }
+        });
+
+        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+        glfwSetWindowPos(window, (vidmode.width() - width) / 2, (vidmode.height() - height) / 2);
+        glfwMakeContextCurrent(window);
+        glfwSwapInterval(1);
+        glfwShowWindow(window);
+        caps = GL.createCapabilities();
+        debugProc = GLUtil.setupDebugMessageCallback();
+
+        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    }
+
+    public abstract void render();
+
+    private void loop() {
+        while (!glfwWindowShouldClose(window)) {
+            glfwPollEvents();
+            glViewport(0, 0, width, height);
+
+            render();
+
+            glfwSwapBuffers(window);
+        }
+    }
+
+    public void run() {
+        try {
+            init();
+            loop();
+
+            if (debugProc != null) {
+                debugProc.free();
+            }
+
+            errCallback.free();
+            keyCallback.free();
+            fbCallback.free();
+            glfwDestroyWindow(window);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        } finally {
+            glfwTerminate();
+        }
+    }
+}

--- a/src/org/lwjgl/demo/opengl/shader/ImmediateModeDemo.java
+++ b/src/org/lwjgl/demo/opengl/shader/ImmediateModeDemo.java
@@ -4,109 +4,55 @@
  */
 package org.lwjgl.demo.opengl.shader;
 
-import static org.lwjgl.demo.opengl.util.DemoUtils.createShader;
-import static org.lwjgl.glfw.GLFW.*;
-import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL20.*;
-import static org.lwjgl.system.MemoryUtil.NULL;
+import org.joml.Matrix3f;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.demo.opengl.Example;
 
 import java.io.IOException;
 import java.nio.FloatBuffer;
 
-import org.joml.Matrix3f;
-import org.lwjgl.BufferUtils;
-import org.lwjgl.glfw.GLFWErrorCallback;
-import org.lwjgl.glfw.GLFWFramebufferSizeCallback;
-import org.lwjgl.glfw.GLFWKeyCallback;
-import org.lwjgl.glfw.GLFWVidMode;
-import org.lwjgl.opengl.GL;
-import org.lwjgl.opengl.GLCapabilities;
-import org.lwjgl.opengl.GLUtil;
-import org.lwjgl.system.Callback;
+import static org.lwjgl.demo.opengl.util.DemoUtils.createShader;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_FRONT_AND_BACK;
+import static org.lwjgl.opengl.GL11.GL_LINE;
+import static org.lwjgl.opengl.GL11.GL_QUADS;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glPolygonMode;
+import static org.lwjgl.opengl.GL11.glVertex2f;
+import static org.lwjgl.opengl.GL20.GL_FRAGMENT_SHADER;
+import static org.lwjgl.opengl.GL20.GL_LINK_STATUS;
+import static org.lwjgl.opengl.GL20.GL_VERTEX_SHADER;
+import static org.lwjgl.opengl.GL20.glAttachShader;
+import static org.lwjgl.opengl.GL20.glCreateProgram;
+import static org.lwjgl.opengl.GL20.glGetProgramInfoLog;
+import static org.lwjgl.opengl.GL20.glGetProgrami;
+import static org.lwjgl.opengl.GL20.glGetUniformLocation;
+import static org.lwjgl.opengl.GL20.glLinkProgram;
+import static org.lwjgl.opengl.GL20.glUniformMatrix3fv;
+import static org.lwjgl.opengl.GL20.glUseProgram;
 
 /**
  * Shows how to use immediate mode with a simple shader.
  * 
  * @author Kai Burjack
  */
-public class ImmediateModeDemo {
+public class ImmediateModeDemo extends Example {
 
-    long window;
-    int width = 1024;
-    int height = 768;
+    private int program;
+    private int transformUniform;
 
-    int program;
-    int transformUniform;
+    private FloatBuffer matrixBuffer = BufferUtils.createFloatBuffer(9);
+    private Matrix3f transform = new Matrix3f();
 
-    GLCapabilities caps;
-    GLFWErrorCallback errCallback;
-    GLFWKeyCallback keyCallback;
-    GLFWFramebufferSizeCallback fbCallback;
-    Callback debugProc;
+    private float angle = 0.0f;
+    private long lastTime = System.nanoTime();
 
-    FloatBuffer matrixBuffer = BufferUtils.createFloatBuffer(9);
-    Matrix3f transform = new Matrix3f();
 
-    void init() throws IOException {
-        glfwSetErrorCallback(errCallback = new GLFWErrorCallback() {
-            GLFWErrorCallback delegate = GLFWErrorCallback.createPrint(System.err);
-
-            @Override
-            public void invoke(int error, long description) {
-                if (error == GLFW_VERSION_UNAVAILABLE)
-                    System.err.println("This demo requires OpenGL 2.0 or higher.");
-                delegate.invoke(error, description);
-            }
-
-            @Override
-            public void free() {
-                delegate.free();
-            }
-        });
-
-        if (!glfwInit())
-            throw new IllegalStateException("Unable to initialize GLFW");
-
-        glfwDefaultWindowHints();
-        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-        glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-
-        window = glfwCreateWindow(width, height, "Immediate mode shader demo", NULL, NULL);
-        if (window == NULL) {
-            throw new AssertionError("Failed to create the GLFW window");
-        }
-
-        glfwSetFramebufferSizeCallback(window, fbCallback = new GLFWFramebufferSizeCallback() {
-            @Override
-            public void invoke(long window, int width, int height) {
-                if (width > 0 && height > 0 && (ImmediateModeDemo.this.width != width || ImmediateModeDemo.this.height != height)) {
-                    ImmediateModeDemo.this.width = width;
-                    ImmediateModeDemo.this.height = height;
-                }
-            }
-        });
-
-        glfwSetKeyCallback(window, keyCallback = new GLFWKeyCallback() {
-            @Override
-            public void invoke(long window, int key, int scancode, int action, int mods) {
-                if (action != GLFW_RELEASE)
-                    return;
-
-                if (key == GLFW_KEY_ESCAPE) {
-                    glfwSetWindowShouldClose(window, true);
-                }
-            }
-        });
-
-        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
-        glfwSetWindowPos(window, (vidmode.width() - width) / 2, (vidmode.height() - height) / 2);
-        glfwMakeContextCurrent(window);
-        glfwSwapInterval(1);
-        glfwShowWindow(window);
-        caps = GL.createCapabilities();
-        debugProc = GLUtil.setupDebugMessageCallback();
-
-        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    @Override
+    protected void init() throws IOException {
+        super.init();
 
         // Create all needed GL resources
         createProgram();
@@ -114,32 +60,9 @@ public class ImmediateModeDemo {
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     }
 
-    void createProgram() throws IOException {
-        int program = glCreateProgram();
-        int vshader = createShader("org/lwjgl/demo/opengl/shader/simple.vs", GL_VERTEX_SHADER);
-        int fshader = createShader("org/lwjgl/demo/opengl/shader/simple.fs", GL_FRAGMENT_SHADER);
-        glAttachShader(program, vshader);
-        glAttachShader(program, fshader);
-        glLinkProgram(program);
-        int linked = glGetProgrami(program, GL_LINK_STATUS);
-        String programLog = glGetProgramInfoLog(program);
-        if (programLog.trim().length() > 0) {
-            System.err.println(programLog);
-        }
-        if (linked == 0) {
-            throw new AssertionError("Could not link program");
-        }
-        this.program = program;
-        glUseProgram(program);
-        transformUniform = glGetUniformLocation(program, "transform");
-        glUseProgram(0);
-    }
-
-    float angle = 0.0f;
-    long lastTime = System.nanoTime();
-    void render() {
+    @Override
+    public void render() {
         glClear(GL_COLOR_BUFFER_BIT);
-
         glUseProgram(this.program);
 
         // Compute rotation angle
@@ -167,35 +90,25 @@ public class ImmediateModeDemo {
         glUseProgram(0);
     }
 
-    void loop() {
-        while (!glfwWindowShouldClose(window)) {
-            glfwPollEvents();
-            glViewport(0, 0, width, height);
-
-            render();
-
-            glfwSwapBuffers(window);
+    private void createProgram() throws IOException {
+        int program = glCreateProgram();
+        int vshader = createShader("org/lwjgl/demo/opengl/shader/simple.vs", GL_VERTEX_SHADER);
+        int fshader = createShader("org/lwjgl/demo/opengl/shader/simple.fs", GL_FRAGMENT_SHADER);
+        glAttachShader(program, vshader);
+        glAttachShader(program, fshader);
+        glLinkProgram(program);
+        int linked = glGetProgrami(program, GL_LINK_STATUS);
+        String programLog = glGetProgramInfoLog(program);
+        if (programLog.trim().length() > 0) {
+            System.err.println(programLog);
         }
-    }
-
-    void run() {
-        try {
-            init();
-            loop();
-
-            if (debugProc != null) {
-                debugProc.free();
-            }
-
-            errCallback.free();
-            keyCallback.free();
-            fbCallback.free();
-            glfwDestroyWindow(window);
-        } catch (Throwable t) {
-            t.printStackTrace();
-        } finally {
-            glfwTerminate();
+        if (linked == 0) {
+            throw new AssertionError("Could not link program");
         }
+        this.program = program;
+        glUseProgram(program);
+        transformUniform = glGetUniformLocation(program, "transform");
+        glUseProgram(0);
     }
 
     public static void main(String[] args) {

--- a/src/org/lwjgl/demo/opengl/shader/NoVerticesBSplineDemo.java
+++ b/src/org/lwjgl/demo/opengl/shader/NoVerticesBSplineDemo.java
@@ -4,29 +4,40 @@
  */
 package org.lwjgl.demo.opengl.shader;
 
-import static org.lwjgl.demo.opengl.util.DemoUtils.createShader;
-import static org.lwjgl.glfw.GLFW.*;
-import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL15.*;
-import static org.lwjgl.opengl.GL20.*;
-import static org.lwjgl.opengl.GL30.*;
-import static org.lwjgl.opengl.GL31.*;
-import static org.lwjgl.system.MemoryUtil.NULL;
+import org.joml.Matrix4f;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.demo.opengl.Example;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
-import org.joml.Matrix4f;
-import org.lwjgl.BufferUtils;
-import org.lwjgl.glfw.GLFWErrorCallback;
-import org.lwjgl.glfw.GLFWFramebufferSizeCallback;
-import org.lwjgl.glfw.GLFWKeyCallback;
-import org.lwjgl.glfw.GLFWVidMode;
-import org.lwjgl.opengl.GL;
-import org.lwjgl.opengl.GLCapabilities;
-import org.lwjgl.opengl.GLUtil;
-import org.lwjgl.system.Callback;
+import static org.lwjgl.demo.opengl.util.DemoUtils.createShader;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_FRONT_AND_BACK;
+import static org.lwjgl.opengl.GL11.GL_LINE;
+import static org.lwjgl.opengl.GL11.GL_LINE_STRIP;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glDrawArrays;
+import static org.lwjgl.opengl.GL11.glPolygonMode;
+import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.glBindBuffer;
+import static org.lwjgl.opengl.GL15.glBufferData;
+import static org.lwjgl.opengl.GL15.glGenBuffers;
+import static org.lwjgl.opengl.GL20.GL_FRAGMENT_SHADER;
+import static org.lwjgl.opengl.GL20.GL_LINK_STATUS;
+import static org.lwjgl.opengl.GL20.GL_VERTEX_SHADER;
+import static org.lwjgl.opengl.GL20.glAttachShader;
+import static org.lwjgl.opengl.GL20.glCreateProgram;
+import static org.lwjgl.opengl.GL20.glGetProgramInfoLog;
+import static org.lwjgl.opengl.GL20.glGetProgrami;
+import static org.lwjgl.opengl.GL20.glGetUniformLocation;
+import static org.lwjgl.opengl.GL20.glLinkProgram;
+import static org.lwjgl.opengl.GL20.glUniform1i;
+import static org.lwjgl.opengl.GL20.glUniformMatrix4fv;
+import static org.lwjgl.opengl.GL20.glUseProgram;
+import static org.lwjgl.opengl.GL30.glBindBufferBase;
+import static org.lwjgl.opengl.GL31.GL_UNIFORM_BUFFER;
 
 /**
  * Renders a cubic B-spline without using any vertex source but fully computing the vertex positions in the vertex shader.
@@ -35,95 +46,26 @@ import org.lwjgl.system.Callback;
  * 
  * @author Kai Burjack
  */
-public class NoVerticesBSplineDemo {
+public class NoVerticesBSplineDemo extends Example {
 
-    long window;
-    int width = 1024;
-    int height = 768;
+    private static final int POINT_COUNT = 50;
 
-    int program;
-    int transformUniform;
-    int lodUniform;
-    int numPointsUniform;
+    private static final int LOD = 10;
 
-    GLCapabilities caps;
-    GLFWErrorCallback errCallback;
-    GLFWKeyCallback keyCallback;
-    GLFWFramebufferSizeCallback fbCallback;
-    Callback debugProc;
+    private int program;
+    private int transformUniform;
+    private int lodUniform;
+    private int numPointsUniform;
 
-    FloatBuffer matrixBuffer = BufferUtils.createFloatBuffer(16);
-    Matrix4f transform = new Matrix4f();
-    int lod = 10;
-    static final int numPoints = 50;
+    private FloatBuffer matrixBuffer = BufferUtils.createFloatBuffer(16);
+    private Matrix4f transform = new Matrix4f();
 
-    void init() throws IOException {
-        glfwSetErrorCallback(errCallback = new GLFWErrorCallback() {
-            GLFWErrorCallback delegate = GLFWErrorCallback.createPrint(System.err);
+    private float angle = 0.0f;
+    private long lastTime = System.nanoTime();
 
-            @Override
-            public void invoke(int error, long description) {
-                if (error == GLFW_VERSION_UNAVAILABLE)
-                    System.err.println("This demo requires OpenGL 3.0 or higher.");
-                delegate.invoke(error, description);
-            }
-
-            @Override
-            public void free() {
-                delegate.free();
-            }
-        });
-
-        if (!glfwInit())
-            throw new IllegalStateException("Unable to initialize GLFW");
-
-        glfwDefaultWindowHints();
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
-        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-        glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE);
-
-        window = glfwCreateWindow(width, height, "No vertices cubic B-splines shader demo", NULL, NULL);
-        if (window == NULL) {
-            throw new AssertionError("Failed to create the GLFW window");
-        }
-
-        glfwSetFramebufferSizeCallback(window, fbCallback = new GLFWFramebufferSizeCallback() {
-            @Override
-            public void invoke(long window, int width, int height) {
-                if (width > 0 && height > 0 && (NoVerticesBSplineDemo.this.width != width || NoVerticesBSplineDemo.this.height != height)) {
-                    NoVerticesBSplineDemo.this.width = width;
-                    NoVerticesBSplineDemo.this.height = height;
-                }
-            }
-        });
-
-        System.out.println("Press 'arrow up' to increase the lod");
-        System.out.println("Press 'arrow down' to decrease the lod");
-        glfwSetKeyCallback(window, keyCallback = new GLFWKeyCallback() {
-            @Override
-            public void invoke(long window, int key, int scancode, int action, int mods) {
-                if (key == GLFW_KEY_ESCAPE && action == GLFW_RELEASE) {
-                    glfwSetWindowShouldClose(window, true);
-                } else if (key == GLFW_KEY_UP && (action == GLFW_RELEASE || action == GLFW_REPEAT)) {
-                    lod++;
-                    System.out.println("Increased LOD to " + lod);
-                } else if (key == GLFW_KEY_DOWN && (action == GLFW_RELEASE || action == GLFW_REPEAT)) {
-                    lod = Math.max(1, lod - 1);
-                    System.out.println("Decreased LOD to " + lod);
-                }
-            }
-        });
-
-        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
-        glfwSetWindowPos(window, (vidmode.width() - width) / 2, (vidmode.height() - height) / 2);
-        glfwMakeContextCurrent(window);
-        glfwSwapInterval(1);
-        glfwShowWindow(window);
-        caps = GL.createCapabilities();
-        debugProc = GLUtil.setupDebugMessageCallback();
-
-        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    @Override
+    public void init() throws IOException {
+        super.init();
 
         // Create all needed GL resources
         createProgram();
@@ -132,7 +74,36 @@ public class NoVerticesBSplineDemo {
         glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
     }
 
-    void createProgram() throws IOException {
+    @Override
+    public void render() {
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        glUseProgram(this.program);
+
+        // Compute rotation angle
+        long thisTime = System.nanoTime();
+        float delta = (thisTime - lastTime) / 1E9f;
+        angle += delta;
+        lastTime = thisTime;
+
+        // Build some transformation matrix
+        transform.setPerspective((float) Math.toRadians(45.0f), (float)width/height, 0.1f, 100.0f)
+                .lookAt(0, 0, 6,
+                        0, 2, 0,
+                        0, 1, 0)
+                .rotateY(angle * (float) Math.toRadians(180)); // 180 degrees per second
+        // and upload it to the shader
+        glUniformMatrix4fv(transformUniform, false, transform.get(matrixBuffer));
+
+        glUniform1i(lodUniform, LOD);
+        glUniform1i(numPointsUniform, POINT_COUNT);
+
+        glDrawArrays(GL_LINE_STRIP, 0, LOD * (POINT_COUNT +1) + 1);
+
+        glUseProgram(0);
+    }
+
+    private void createProgram() throws IOException {
         int program = glCreateProgram();
         int vshader = createShader("org/lwjgl/demo/opengl/shader/noverticesbspline.vs", GL_VERTEX_SHADER);
         int fshader = createShader("org/lwjgl/demo/opengl/shader/noverticesbspline.fs", GL_FRAGMENT_SHADER);
@@ -155,14 +126,14 @@ public class NoVerticesBSplineDemo {
         glUseProgram(0);
     }
 
-    static void createUbo() {
+    private static void createUbo() {
         int ubo = glGenBuffers();
         glBindBuffer(GL_UNIFORM_BUFFER, ubo);
         int pointsPerCircle = 5;
-        ByteBuffer bb = BufferUtils.createByteBuffer(numPoints * 4 * 4);
+        ByteBuffer bb = BufferUtils.createByteBuffer(POINT_COUNT * 4 * 4);
         FloatBuffer fb = bb.asFloatBuffer();
-        for (int i = 0; i < numPoints; i++) {
-            float scale = 1.0f - (float)i/numPoints;
+        for (int i = 0; i < POINT_COUNT; i++) {
+            float scale = 1.0f - (float)i/ POINT_COUNT;
             float t = (float)i / pointsPerCircle;
             float ang = 2.0f * (float)Math.PI * t;
             float x = (float) Math.cos(ang) * scale;
@@ -174,64 +145,7 @@ public class NoVerticesBSplineDemo {
         glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo);
     }
 
-    float angle = 0.0f;
-    long lastTime = System.nanoTime();
-    void render() {
-        glClear(GL_COLOR_BUFFER_BIT);
-
-        glUseProgram(this.program);
-
-        // Compute rotation angle
-        long thisTime = System.nanoTime();
-        float delta = (thisTime - lastTime) / 1E9f;
-        angle += delta;
-        lastTime = thisTime;
-
-        // Build some transformation matrix
-        transform.setPerspective((float) Math.toRadians(45.0f), (float)width/height, 0.1f, 100.0f)
-                 .lookAt(0, 0, 6,
-                         0, 2, 0,
-                         0, 1, 0)
-                 .rotateY(angle * (float) Math.toRadians(180)); // 180 degrees per second
-        // and upload it to the shader
-        glUniformMatrix4fv(transformUniform, false, transform.get(matrixBuffer));
-        glUniform1i(lodUniform, lod);
-        glUniform1i(numPointsUniform, numPoints);
-
-        glDrawArrays(GL_LINE_STRIP, 0, lod * (numPoints+1) + 1);
-
-        glUseProgram(0);
-    }
-
-    void loop() {
-        while (!glfwWindowShouldClose(window)) {
-            glfwPollEvents();
-            glViewport(0, 0, width, height);
-            render();
-            glfwSwapBuffers(window);
-        }
-    }
-
-    void run() {
-        try {
-            init();
-            loop();
-            if (debugProc != null) {
-                debugProc.free();
-            }
-            errCallback.free();
-            keyCallback.free();
-            fbCallback.free();
-            glfwDestroyWindow(window);
-        } catch (Throwable t) {
-            t.printStackTrace();
-        } finally {
-            glfwTerminate();
-        }
-    }
-
     public static void main(String[] args) {
         new NoVerticesBSplineDemo().run();
     }
-
 }


### PR DESCRIPTION
Glancing over the opengl examples I found a lot of warnings and bad practices: code duplication, non-private fields and various inconsistencies.

I'd like to propose some simple refactorings to clean up the examples. After all, the examples are probably the first thing new developers see.

This pull request is not complete, but I would like to have some feedback on the proposal. The `ImmediateModeDemo` and `NoVerticesBSplineDemo` have been refactored as examples. The glfw scaffolding (which is duplicated among all examples) has been extracted into a parent class, so that each example only contains logic and state relevant for the example.
