### PR TITLE
Check available layers before creating VulkanInstance

### DIFF
--- a/src/org/lwjgl/demo/vulkan/ColoredRotatingQuadDemo.java
+++ b/src/org/lwjgl/demo/vulkan/ColoredRotatingQuadDemo.java
@@ -93,8 +93,9 @@ import org.lwjgl.vulkan.VkWriteDescriptorSet;
 public class ColoredRotatingQuadDemo {
     private static boolean debug = System.getProperty("NDEBUG") == null;
 
-    private static ByteBuffer[] layers = {
-        memUTF8("VK_LAYER_LUNARG_standard_validation"),
+    private static String[] layers = {
+			"VK_LAYER_LUNARG_standard_validation",
+			"VK_LAYER_KHRONOS_validation",
     };
 
     /**
@@ -116,10 +117,7 @@ public class ColoredRotatingQuadDemo {
         ByteBuffer VK_EXT_DEBUG_REPORT_EXTENSION = memUTF8(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
         ppEnabledExtensionNames.put(VK_EXT_DEBUG_REPORT_EXTENSION);
         ppEnabledExtensionNames.flip();
-        PointerBuffer ppEnabledLayerNames = memAllocPointer(layers.length);
-        for (int i = 0; debug && i < layers.length; i++)
-            ppEnabledLayerNames.put(layers[i]);
-        ppEnabledLayerNames.flip();
+        PointerBuffer ppEnabledLayerNames = debug ? allocateLayerBuffer(layers) : null;
         VkInstanceCreateInfo pCreateInfo = VkInstanceCreateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
                 .pApplicationInfo(appInfo)
@@ -134,7 +132,7 @@ public class ColoredRotatingQuadDemo {
         }
         VkInstance ret = new VkInstance(instance, pCreateInfo);
         pCreateInfo.free();
-        memFree(ppEnabledLayerNames);
+        if(ppEnabledLayerNames != null) memFree(ppEnabledLayerNames);
         memFree(VK_EXT_DEBUG_REPORT_EXTENSION);
         memFree(ppEnabledExtensionNames);
         memFree(appInfo.pApplicationName());
@@ -206,16 +204,11 @@ public class ColoredRotatingQuadDemo {
         ByteBuffer VK_KHR_SWAPCHAIN_EXTENSION = memUTF8(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
         extensions.put(VK_KHR_SWAPCHAIN_EXTENSION);
         extensions.flip();
-        PointerBuffer ppEnabledLayerNames = memAllocPointer(layers.length);
-        for (int i = 0; debug && i < layers.length; i++)
-            ppEnabledLayerNames.put(layers[i]);
-        ppEnabledLayerNames.flip();
 
         VkDeviceCreateInfo deviceCreateInfo = VkDeviceCreateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
                 .pQueueCreateInfos(queueCreateInfo)
-                .ppEnabledExtensionNames(extensions)
-                .ppEnabledLayerNames(ppEnabledLayerNames);
+                .ppEnabledExtensionNames(extensions);
 
         PointerBuffer pDevice = memAllocPointer(1);
         int err = vkCreateDevice(physicalDevice, deviceCreateInfo, null, pDevice);
@@ -234,7 +227,6 @@ public class ColoredRotatingQuadDemo {
         ret.memoryProperties = memoryProperties;
 
         deviceCreateInfo.free();
-        memFree(ppEnabledLayerNames);
         memFree(VK_KHR_SWAPCHAIN_EXTENSION);
         memFree(extensions);
         memFree(pQueuePriorities);

--- a/src/org/lwjgl/demo/vulkan/ColoredTriangleDemo.java
+++ b/src/org/lwjgl/demo/vulkan/ColoredTriangleDemo.java
@@ -85,8 +85,9 @@ import org.lwjgl.vulkan.VkViewport;
 public class ColoredTriangleDemo {
     private static boolean debug = System.getProperty("NDEBUG") == null;
 
-    private static ByteBuffer[] layers = {
-            memUTF8("VK_LAYER_LUNARG_standard_validation"),
+    private static String[] layers = {
+			"VK_LAYER_LUNARG_standard_validation",
+			"VK_LAYER_KHRONOS_validation",
     };
 
     /**
@@ -108,10 +109,7 @@ public class ColoredTriangleDemo {
         ByteBuffer VK_EXT_DEBUG_REPORT_EXTENSION = memUTF8(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
         ppEnabledExtensionNames.put(VK_EXT_DEBUG_REPORT_EXTENSION);
         ppEnabledExtensionNames.flip();
-        PointerBuffer ppEnabledLayerNames = memAllocPointer(layers.length);
-        for (int i = 0; debug && i < layers.length; i++)
-            ppEnabledLayerNames.put(layers[i]);
-        ppEnabledLayerNames.flip();
+        PointerBuffer ppEnabledLayerNames = debug ? allocateLayerBuffer(layers) : null;
         VkInstanceCreateInfo pCreateInfo = VkInstanceCreateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
                 .pApplicationInfo(appInfo)
@@ -126,7 +124,7 @@ public class ColoredTriangleDemo {
         }
         VkInstance ret = new VkInstance(instance, pCreateInfo);
         pCreateInfo.free();
-        memFree(ppEnabledLayerNames);
+        if(ppEnabledLayerNames != null) memFree(ppEnabledLayerNames);
         memFree(VK_EXT_DEBUG_REPORT_EXTENSION);
         memFree(ppEnabledExtensionNames);
         memFree(appInfo.pApplicationName());
@@ -198,16 +196,11 @@ public class ColoredTriangleDemo {
         ByteBuffer VK_KHR_SWAPCHAIN_EXTENSION = memUTF8(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
         extensions.put(VK_KHR_SWAPCHAIN_EXTENSION);
         extensions.flip();
-        PointerBuffer ppEnabledLayerNames = memAllocPointer(layers.length);
-        for (int i = 0; debug && i < layers.length; i++)
-            ppEnabledLayerNames.put(layers[i]);
-        ppEnabledLayerNames.flip();
 
         VkDeviceCreateInfo deviceCreateInfo = VkDeviceCreateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
                 .pQueueCreateInfos(queueCreateInfo)
-                .ppEnabledExtensionNames(extensions)
-                .ppEnabledLayerNames(ppEnabledLayerNames);
+                .ppEnabledExtensionNames(extensions);
 
         PointerBuffer pDevice = memAllocPointer(1);
         int err = vkCreateDevice(physicalDevice, deviceCreateInfo, null, pDevice);
@@ -226,7 +219,6 @@ public class ColoredTriangleDemo {
         ret.memoryProperties = memoryProperties;
 
         deviceCreateInfo.free();
-        memFree(ppEnabledLayerNames);
         memFree(VK_KHR_SWAPCHAIN_EXTENSION);
         memFree(extensions);
         memFree(pQueuePriorities);

--- a/src/org/lwjgl/demo/vulkan/InstancedSpheresDemo.java
+++ b/src/org/lwjgl/demo/vulkan/InstancedSpheresDemo.java
@@ -38,8 +38,9 @@ import static org.lwjgl.demo.vulkan.VKUtil.*;
 public class InstancedSpheresDemo {
     private static boolean debug = System.getProperty("NDEBUG") == null;
 
-    private static ByteBuffer[] layers = {
-            memUTF8("VK_LAYER_LUNARG_standard_validation"),
+    private static String[] layers = {
+            "VK_LAYER_LUNARG_standard_validation",
+            "VK_LAYER_KHRONOS_validation",
     };
 
     /**
@@ -82,10 +83,7 @@ public class InstancedSpheresDemo {
         ByteBuffer VK_EXT_DEBUG_REPORT_EXTENSION = memUTF8(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
         ppEnabledExtensionNames.put(VK_EXT_DEBUG_REPORT_EXTENSION);
         ppEnabledExtensionNames.flip();
-        PointerBuffer ppEnabledLayerNames = memAllocPointer(layers.length);
-        for (int i = 0; debug && i < layers.length; i++)
-            ppEnabledLayerNames.put(layers[i]);
-        ppEnabledLayerNames.flip();
+        PointerBuffer ppEnabledLayerNames = debug ? allocateLayerBuffer(layers) : null;
         VkInstanceCreateInfo pCreateInfo = VkInstanceCreateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
                 .pApplicationInfo(appInfo)
@@ -100,7 +98,7 @@ public class InstancedSpheresDemo {
         }
         VkInstance ret = new VkInstance(instance, pCreateInfo);
         pCreateInfo.free();
-        memFree(ppEnabledLayerNames);
+        if(ppEnabledLayerNames != null) memFree(ppEnabledLayerNames);
         memFree(VK_EXT_DEBUG_REPORT_EXTENSION);
         memFree(ppEnabledExtensionNames);
         memFree(appInfo.pApplicationName());
@@ -172,16 +170,11 @@ public class InstancedSpheresDemo {
         ByteBuffer VK_KHR_SWAPCHAIN_EXTENSION = memUTF8(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
         extensions.put(VK_KHR_SWAPCHAIN_EXTENSION);
         extensions.flip();
-        PointerBuffer ppEnabledLayerNames = memAllocPointer(layers.length);
-        for (int i = 0; debug && i < layers.length; i++)
-            ppEnabledLayerNames.put(layers[i]);
-        ppEnabledLayerNames.flip();
 
         VkDeviceCreateInfo deviceCreateInfo = VkDeviceCreateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
                 .pQueueCreateInfos(queueCreateInfo)
-                .ppEnabledExtensionNames(extensions)
-                .ppEnabledLayerNames(ppEnabledLayerNames);
+                .ppEnabledExtensionNames(extensions);
 
         PointerBuffer pDevice = memAllocPointer(1);
         int err = vkCreateDevice(physicalDevice, deviceCreateInfo, null, pDevice);
@@ -200,7 +193,6 @@ public class InstancedSpheresDemo {
         ret.memoryProperties = memoryProperties;
 
         deviceCreateInfo.free();
-        memFree(ppEnabledLayerNames);
         memFree(VK_KHR_SWAPCHAIN_EXTENSION);
         memFree(extensions);
         memFree(pQueuePriorities);


### PR DESCRIPTION
Before creating the VkInstance, this code will first check if the layer is available. Prevent a crash if the layer is not available.

I made two other little changes : 
* *VK_LAYER_LUNARG_standard_validation* [is deprecated](https://vulkan.lunarg.com/doc/view/1.1.114.0/windows/validation_layers.html), the official replacement is *VK_LAYER_KHRONOS_validation*.

* _ppEnabledLayerNames_ on _VkDeviceCreateInfo_ [is deprecated](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VkDeviceCreateInfo), and not applicable for the validation layers we use. It happened to me that some bad drivers literally crashed if this field is used...