### PR TITLE
Fix bad cast from an Allocation to a VmaAllocationInfo 

### DIFF
--- a/src/org/lwjgl/demo/vulkan/VKUtil.java
+++ b/src/org/lwjgl/demo/vulkan/VKUtil.java
@@ -22,6 +22,7 @@ import java.util.*;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.*;
 import org.lwjgl.util.shaderc.*;
+import org.lwjgl.util.vma.VmaAllocationInfo;
 import org.lwjgl.vulkan.*;
 
 /**
@@ -230,5 +231,10 @@ public class VKUtil {
             pointerBuffer.put(i, addr + sizeof * i);
         }
         return pointerBuffer;
+    }
+
+    public static void validateAlignment(VmaAllocationInfo pAllocationInfo, long alignment) {
+        if ((pAllocationInfo.offset() % alignment) != 0)
+            throw new AssertionError("Illegal offset alignment");
     }
 }

--- a/src/org/lwjgl/demo/vulkan/raytracing/HybridMagicaVoxel.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/HybridMagicaVoxel.java
@@ -1087,6 +1087,8 @@ public class HybridMagicaVoxel {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -1095,13 +1097,10 @@ public class HybridMagicaVoxel {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/HybridMagicaVoxel.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/HybridMagicaVoxel.java
@@ -1087,7 +1087,7 @@ public class HybridMagicaVoxel {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
 
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo

--- a/src/org/lwjgl/demo/vulkan/raytracing/ReflectiveMagicaVoxel.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/ReflectiveMagicaVoxel.java
@@ -883,7 +883,7 @@ public class ReflectiveMagicaVoxel {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)

--- a/src/org/lwjgl/demo/vulkan/raytracing/ReflectiveMagicaVoxel.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/ReflectiveMagicaVoxel.java
@@ -883,6 +883,7 @@ public class ReflectiveMagicaVoxel {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -891,13 +892,10 @@ public class ReflectiveMagicaVoxel {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/SdfBricks.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SdfBricks.java
@@ -878,6 +878,7 @@ public class SdfBricks {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -886,13 +887,10 @@ public class SdfBricks {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/SdfBricks.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SdfBricks.java
@@ -878,7 +878,7 @@ public class SdfBricks {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)

--- a/src/org/lwjgl/demo/vulkan/raytracing/SimpleSphere.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SimpleSphere.java
@@ -839,6 +839,7 @@ public class SimpleSphere {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -847,13 +848,10 @@ public class SimpleSphere {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/SimpleSphere.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SimpleSphere.java
@@ -839,7 +839,7 @@ public class SimpleSphere {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)

--- a/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangle.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangle.java
@@ -843,7 +843,7 @@ public class SimpleTriangle {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)

--- a/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangle.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangle.java
@@ -843,6 +843,7 @@ public class SimpleTriangle {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -851,13 +852,10 @@ public class SimpleTriangle {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangleRayQuery.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangleRayQuery.java
@@ -836,7 +836,7 @@ public class SimpleTriangleRayQuery {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)

--- a/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangleRayQuery.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/SimpleTriangleRayQuery.java
@@ -836,6 +836,7 @@ public class SimpleTriangleRayQuery {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -844,13 +845,10 @@ public class SimpleTriangleRayQuery {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/VoxelChunks.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/VoxelChunks.java
@@ -915,6 +915,7 @@ public class VoxelChunks {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)
@@ -923,13 +924,10 @@ public class VoxelChunks {
                         .usage(usageFlags | (data != null ? VK_BUFFER_USAGE_TRANSFER_DST_BIT : 0)),
                     VmaAllocationCreateInfo
                         .calloc(stack)
-                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, null),
+                        .usage(VMA_MEMORY_USAGE_AUTO), pBuffer, pAllocation, pAllocationInfo),
                     "Failed to allocate buffer");
 
-            // validate alignment
-            VmaAllocationInfo ai = VmaAllocationInfo.create(pAllocation.get(0));
-            if ((ai.offset() % alignment) != 0)
-                throw new AssertionError("Illegal offset alignment");
+            validateAlignment(pAllocationInfo, alignment);
 
             // if we have data to upload, use a staging buffer
             if (data != null) {

--- a/src/org/lwjgl/demo/vulkan/raytracing/VoxelChunks.java
+++ b/src/org/lwjgl/demo/vulkan/raytracing/VoxelChunks.java
@@ -915,7 +915,7 @@ public class VoxelChunks {
             // create the final destination buffer
             LongBuffer pBuffer = stack.mallocLong(1);
             PointerBuffer pAllocation = stack.mallocPointer(1);
-            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.calloc(stack);
+            VmaAllocationInfo pAllocationInfo = VmaAllocationInfo.malloc(stack);
             _CHECK_(vmaCreateBuffer(vmaAllocator,
                     VkBufferCreateInfo
                         .calloc(stack)


### PR DESCRIPTION
The alignment check on `createBuffer()` from the raytracing examples was failing when disabling `jemalloc` , talking with @Spasi he figured this is caused by a bad cast.

I hope this is useful.