### PR TITLE
Add support for arm-based MacOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
             <activation>
                 <os>
                     <family>Mac</family>
+                    <arch>x86_64</arch>
                 </os>
             </activation>
             <properties>
@@ -155,7 +156,38 @@
                     <groupId>org.lwjgl</groupId>
                     <artifactId>lwjgl-vulkan</artifactId>
                     <version>${lwjgl.version}</version>
-                    <classifier>natives-macos</classifier>
+                    <classifier>natives-${platform}</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>mac-arm64</id>
+            <activation>
+                <os>
+                    <family>Mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <platform>macos-arm64</platform>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.platform</groupId>
+                    <artifactId>org.eclipse.swt.cocoa.macosx.aarch64</artifactId>
+                    <version>${swt.maven.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.eclipse.platform</groupId>
+                            <artifactId>org.eclipse.swt</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.lwjgl</groupId>
+                    <artifactId>lwjgl-vulkan</artifactId>
+                    <version>${lwjgl.version}</version>
+                    <classifier>natives-${platform}</classifier>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
List of demos, from which:

* checked ones are working on my machine
* unchecked ones have not been tried out yet
* unchecked with error I'll leave some info

My specs:

* Macbook M1 Pro 2021
* openjdk 23.0.2 2025-01-21 
* **Edit**: using version 3.4.0-SNAPSHOT of lwjgl, then more things work

All demos have been executed with the below command:

```shellscript
java -Dorg.lwjgl.util.Debug=true \
-Dorg.lwjgl.util.DebugLoader=true \
-XstartOnFirstThread \
-cp target/lwjgl3-demos.jar <class name>
```

-   ### `org.lwjgl.demo.bgfx`
    - [ ] `org.lwjgl.demo.bgfx.Bump` 
    - [ ] `org.lwjgl.demo.bgfx.Cubes`
    - [ ] `org.lwjgl.demo.bgfx.Metaballs`
    - [ ] `org.lwjgl.demo.bgfx.Raymarch`

**For all above demos:** no window is shown, but it somehow runs

-   ### `org.lwjgl.demo.cuda`
    - [ ] `org.lwjgl.demo.cuda.OpenGLExample`
    - [ ] `org.lwjgl.demo.cuda.SequencePTX`

If I understood correct, CUDA does not work in MacOS at all

-   ### `org.lwjgl.demo.game`
    - [ ] `org.lwjgl.demo.game.VoxelGameGL`

It runs, but there's an exception and I only see a white-ish screen:

<details>

<summary>Click to see the details</summary>

Exception:

```
Exception in thread "Render Thread" java.lang.NoClassDefFoundError: Could not initialize class org.joml.MemUtil$MemUtilUnsafe
        at org.joml.Matrix4f.getToAddress(Matrix4f.java:3384)
        at org.lwjgl.demo.game.VoxelGameGL.updateChunksProgramUbo(VoxelGameGL.java:3016)
        at org.lwjgl.demo.game.VoxelGameGL.drawChunksWithMultiDrawElementsBaseVertex(VoxelGameGL.java:2931)
        at org.lwjgl.demo.game.VoxelGameGL.runUpdateAndRenderLoop(VoxelGameGL.java:3278)
        at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsupportedOperationException: Unexpected Matrix4f element offset [in thread "Render Thread"]
        at org.joml.MemUtil$MemUtilUnsafe.checkMatrix4f(MemUtil.java:3986)
        at org.joml.MemUtil$MemUtilUnsafe.<clinit>(MemUtil.java:3942)
        at org.joml.MemUtil.createInstance(MemUtil.java:50)
        at org.joml.MemUtil.<clinit>(MemUtil.java:40)
        at org.joml.Matrix4f.setPerspective(Matrix4f.java:10003)
        at org.lwjgl.demo.game.VoxelGameGL.updatePlayerPositionAndMatrices(VoxelGameGL.java:2284)
        at org.lwjgl.demo.game.VoxelGameGL.runUpdateAndRenderLoop(VoxelGameGL.java:3266)
        ... 1 more
```

What I see:

<img width="1059" height="724" alt="image" src="https://github.com/user-attachments/assets/5bd7fcdd-9014-4146-82d9-8d277b8490fa" />

</details>

-   ### `org.lwjgl.demo.intro`
    - [x] `org.lwjgl.demo.intro.Intro1`
    - [x] `org.lwjgl.demo.intro.Intro2`
    - [x] `org.lwjgl.demo.intro.Intro3`
    - [x] `org.lwjgl.demo.intro.Intro4`
    - [x] `org.lwjgl.demo.intro.Intro5`

-   ### `org.lwjgl.demo.opengl`
    - [x] `org.lwjgl.demo.opengl.assimp.WavefrontObjDemo`
    - [x] `org.lwjgl.demo.opengl.camera.ArcballCameraDemo`
    - [x] `org.lwjgl.demo.opengl.camera.FreeCameraDemo`
    - [x] `org.lwjgl.demo.opengl.fbo.DepthEdgeShaderDemo20`
    - [x] `org.lwjgl.demo.opengl.fbo.EdgeShaderDemo20`
    - [x] `org.lwjgl.demo.opengl.fbo.EdgeShaderMultisampleDemo20`
    - [x] `org.lwjgl.demo.opengl.fbo.MultisampledFbo2Demo`
    - [x] `org.lwjgl.demo.opengl.fbo.MultisampledFboDemo`
    - [x] `org.lwjgl.demo.opengl.fbo.ReadDepthBufferDemo`
    - [x] `org.lwjgl.demo.opengl.geometry.GeometryShaderTest`
    - [x] `org.lwjgl.demo.opengl.geometry.GeometryShaderTest20`
    - [x] `org.lwjgl.demo.opengl.geometry.SilhouetteDemo`
    - [x] `org.lwjgl.demo.opengl.glfw.Multithreaded`
    - [ ] `org.lwjgl.demo.opengl.instancing.GrassDemo`
        - Error: ARB_vertex_array_object is not available
    - [x] `org.lwjgl.demo.opengl.PolygonDrawer`
        - It runs, but the drawing position is not exactly where the mouse is. So I'm wondering if this is intended or is a bug in the demo
    - [x] `org.lwjgl.demo.opengl.PolygonDrawer2`
        - Note: can draw exactly where the mouse is
    - [ ] `org.lwjgl.demo.opengl.raytracing.AlphaGrass`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.AtomicDemo`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.CubeTraceMerged`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.Demo`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [x] `org.lwjgl.demo.opengl.raytracing.Demo20`
    - [ ] `org.lwjgl.demo.opengl.raytracing.Demo33`
        - Error: Could not compile shader
    - [ ] `org.lwjgl.demo.opengl.raytracing.Demo33Ubo`
        - Error: Could not compile shader
    - [ ] `org.lwjgl.demo.opengl.raytracing.DemoSsbo`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.DemoSsboTrianglesStacklessKdTree`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [x] `org.lwjgl.demo.opengl.raytracing.GL33KdTreeTrace`
    - [ ] `org.lwjgl.demo.opengl.raytracing.HybridDemo`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.HybridDemoSsbo`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.HybridDemoSsboInstancing`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.HybridDemoSsboInstancing45`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.HybridDemoSsboTriangles`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.LinearlyTransformedCosines`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.TransformFeedbackDemo`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial1`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial2`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial3`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial4`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial4_2`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial4_3`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial5`
        - Error: Failed to create the GLFW window, Requested OpenGL version 4.3, got version 4.1
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial6`
        - Error: Failed to create the GLFW window
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial6_2`
        - Error: Failed to create the GLFW window
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial7`
        - Error: Failed to create the GLFW window
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial8`
        - Error: Could not compile shader
    - [ ] `org.lwjgl.demo.opengl.raytracing.tutorial.Tutorial8_2`
        - Error: Could not compile shader
    - [x] `org.lwjgl.demo.opengl.raytracing.VoxelLightmapping`
        - Note: shadows are flashing, not sure if this is intended
    - [ ] `org.lwjgl.demo.opengl.raytracing.VoxelLightmapping2`
        - Note: shadows are flashing, not sure if this is intended
    - [x] `org.lwjgl.demo.opengl.sampling.HierarchicalSampleWarping`
    - [ ] `org.lwjgl.demo.opengl.shader.DownsamplingDemo`
        - Error: Failed to create the GLFW window
    - [ ] `org.lwjgl.demo.opengl.shader.GameOfLife`
        - Error: JVM crash
    - [x] `org.lwjgl.demo.opengl.shader.ImmediateModeDemo`
    - [x] `org.lwjgl.demo.opengl.shader.InfiniteDraggablePlaneDemo`
    - [x] `org.lwjgl.demo.opengl.shader.InfinitePlaneDemo`
    - [ ] `org.lwjgl.demo.opengl.shader.NoVerticesBSplineDemo`
           - Error: Could not compile shader
    - [ ] `org.lwjgl.demo.opengl.shader.NoVerticesGridDemo`
           - Error: Could not compile shader
    - [x] `org.lwjgl.demo.opengl.shader.NoVerticesPolygonDemo`
    - [ ] `org.lwjgl.demo.opengl.shader.NoVerticesProjectedGridDemo`
           - Error: Could not compile shader
    - [x] `org.lwjgl.demo.opengl.shader.Planet`
    - [x] `org.lwjgl.demo.opengl.shader.RayMarchingVolumeTexture`
    - [x] `org.lwjgl.demo.opengl.shader.SimpleQuadAndGridDemo`
    - [x] `org.lwjgl.demo.opengl.shadow.Omni2dShadow`
        - Note: light is not in the same position as the mouse
    - [x] `org.lwjgl.demo.opengl.shadow.ProjectiveShadowDemo`
    - [ ] `org.lwjgl.demo.opengl.shadow.ShadowMappingDemo`
        - Error: Failed to create the GLFW window
    - [x] `org.lwjgl.demo.opengl.shadow.ShadowMappingDemo20`
    - [x] `org.lwjgl.demo.opengl.SimpleDrawElements`
    - [x] `org.lwjgl.demo.opengl.SimpleTriangleStripGrid`
    - [ ] `org.lwjgl.demo.opengl.swt.SwtAndGlfwDemo`
        - Error: `Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.internal.cocoa.NSGraphicsContext.saveGraphicsState()" because "context" is null`
    - [ ] `org.lwjgl.demo.opengl.swt.SwtDemo`
        - Error: `Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.internal.cocoa.NSGraphicsContext.saveGraphicsState()" because "context" is null`
    - [x] `org.lwjgl.demo.opengl.textures.BillboardCubemapDemo`
    - [x] `org.lwjgl.demo.opengl.textures.EnvironmentDemo`
        - Note: most of the screen is black, there's a little corner where the rendering is happening. Looks like a bug.
    - [x] `org.lwjgl.demo.opengl.textures.EnvironmentTeapotDemo`
        - Note: most of the screen is black, there's a little corner where the rendering is happening. Looks like a bug.
    - [x] `org.lwjgl.demo.opengl.textures.FullscreenCubemapDemo`
    - [x] `org.lwjgl.demo.opengl.textures.SimpleProceduralTextureDemo`
    - [ ] `org.lwjgl.demo.opengl.textures.SimpleTexturedQuad`
        - Error:  `NullPointerException at org.lwjgl.demo.opengl.textures.SimpleTexturedQuad.init(SimpleTexturedQuad.java:52)`
    - [x] `org.lwjgl.demo.opengl.textures.SimpleTexturedSphere`
    - [x] `org.lwjgl.demo.opengl.textures.Texture2DArrayMipmapping`
    - [x] `org.lwjgl.demo.opengl.transform.LwjglDemo`
        - Note: there's no rendering in most of the screen, it's just some squares on a corner. I suspect this is a bug.
    - [x] `org.lwjgl.demo.opengl.transform.LwjglDemoLH`
    - [x] `org.lwjgl.demo.opengl.transform.ObliqueProjectDemo`
        - Note: there's no rendering in most of the screen, it's just some squares on a corner. I suspect this is a bug.
    - [x] `org.lwjgl.demo.opengl.transform.OrientedQuads`
        - Note: there's no rendering in most of the screen, it's just some squares on a corner. I suspect this is a bug. 
   - [x] `org.lwjgl.demo.opengl.UniformArrayDemo`

-   ### `org.lwjgl.demo.util`
    - [x] `org.lwjgl.demo.util.FFT`

-   ### `org.lwjgl.demo.vulkan`
    - [x] `org.lwjgl.demo.vulkan.ClearScreenDemo`
    - [x] `org.lwjgl.demo.vulkan.ColoredRotatingQuadDemo`
    - [x] `org.lwjgl.demo.vulkan.ColoredTriangleDemo`
    - [x] `org.lwjgl.demo.vulkan.InstancedSpheresDemo`
    - [ ] `org.lwjgl.demo.vulkan.raytracing.HybridMagicaVoxel`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [ ] `org.lwjgl.demo.vulkan.raytracing.ReflectiveMagicaVoxel`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [ ] `org.lwjgl.demo.vulkan.raytracing.SdfBricks`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [ ] `org.lwjgl.demo.vulkan.raytracing.SimpleSphere`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [ ] `org.lwjgl.demo.vulkan.raytracing.SimpleTriangle`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [ ] `org.lwjgl.demo.vulkan.raytracing.SimpleTriangleRayQuery`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [ ] `org.lwjgl.demo.vulkan.raytracing.VoxelChunks`
        - requested but layer VK_LAYER_KHRONOS_validation is unavailable. Install the Vulkan SDK for your platform. Vulkan debug layer will not be used. Exception in thread "main" java.lang.AssertionError: No suitable physical device found
    - [x] `org.lwjgl.demo.vulkan.TriangleDemo`
    - [x] `org.lwjgl.demo.vulkan.TwoRotatingTrianglesDemo`
    - [x] `org.lwjgl.demo.vulkan.TwoRotatingTrianglesInvDepthDemo`
